### PR TITLE
Fix gamepass scraper test

### DIFF
--- a/tests/test_scraper_gamepass.py
+++ b/tests/test_scraper_gamepass.py
@@ -1,17 +1,14 @@
 import pytest
-import asyncio
 from app.scrapers.gamepass_scraper import scrape_all_gamepass_games
 
 @pytest.mark.asyncio
-async def run_test():
+async def test_scrape_gamepass():
     print("\n🔎 Ejecutando test para Game Pass Scraper...")
     games = await scrape_all_gamepass_games()
 
     print("\n🧪 Resultados del scraper Game Pass:")
     for g in games[:10]:  # solo los primeros 10 para no saturar la salida
-        print(f"- {g.game} ({', '.join(g.tiers)})")
+        print(f"- {g.title} ({', '.join(g.tiers)})")
 
     print(f"\n✅ Total juegos encontrados: {len(games)}")
 
-if __name__ == "__main__":
-    asyncio.run(run_test())


### PR DESCRIPTION
## Summary
- rename `run_test` to `test_scrape_gamepass`
- drop the `__main__` execution block

## Testing
- `pytest -q tests/test_scraper_gamepass.py` *(fails: ModuleNotFoundError: No module named 'cloudscraper')*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_68496ea1921c83269c34aea5dfc51629