### PR TITLE
Add paginated game endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,8 @@ This API provides endpoints to query information about video game streaming serv
   uvicorn app.main:app --host 0.0.0.0 --port 10000 --reload
   ```
 Your API will be available at http://localhost:10000.
+
+## Endpoints
+
+- `GET /games?page=<number>&limit=<number>` - Lista de juegos paginada.
+- `GET /games/{game_id}` - Devuelve un juego por su `_id`.

--- a/app/routes.py
+++ b/app/routes.py
@@ -9,6 +9,7 @@ from app.services.nintendoonline_service import fill_games_in_nso
 from app.services.psplus_service import fill_games_in_psplus
 from app.services.game_search_service import search_game_by_name
 from app.services.streaming_games_service import fill_games_in_streaming
+from app.services.games_service import get_games_paginated, get_game_by_id
 
 router = APIRouter()
 
@@ -79,3 +80,16 @@ async def search_game(game: str):
         raise HTTPException(status_code=404, detail=f"No se encontró '{game}' en la base de datos.")
 
     return ResponseGameOnline(title=result["title"], tiers=result["tiers"])
+
+
+@router.get("/games", tags=["Games"])
+async def list_games(page: int = 1, limit: int = 10):
+    return await get_games_paginated(page, limit)
+
+
+@router.get("/games/{game_id}", tags=["Games"])
+async def get_game(game_id: str):
+    game = await get_game_by_id(game_id)
+    if not game:
+        raise HTTPException(status_code=404, detail="Game not found")
+    return game

--- a/app/services/games_service.py
+++ b/app/services/games_service.py
@@ -1,0 +1,30 @@
+from typing import List, Optional
+from bson import ObjectId
+from app.database import games_collection
+
+
+async def get_games_paginated(page: int = 1, limit: int = 10) -> List[dict]:
+    """Return games paginated using page and limit."""
+    if page < 1:
+        page = 1
+    if limit < 1:
+        limit = 10
+    skip = (page - 1) * limit
+    cursor = games_collection.find({}).skip(skip).limit(limit)
+    games: List[dict] = []
+    async for game in cursor:
+        game["_id"] = str(game["_id"])
+        games.append(game)
+    return games
+
+
+async def get_game_by_id(game_id: str) -> Optional[dict]:
+    """Return a single game by its MongoDB _id."""
+    try:
+        obj_id = ObjectId(game_id)
+    except Exception:
+        return None
+    game = await games_collection.find_one({"_id": obj_id})
+    if game:
+        game["_id"] = str(game["_id"])
+    return game

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -27,3 +27,30 @@ async def test_post_game_search(mock_search_game_by_name):
     response = client.get("/search?game=Halo")
     assert response.status_code == 200
     assert "Halo" in response.text
+
+
+@patch("app.routes.get_games_paginated", new_callable=AsyncMock)
+@pytest.mark.asyncio
+async def test_get_games_paginated(mock_get_games):
+    mock_get_games.return_value = [
+        {"_id": "1", "title": "Game 1"},
+        {"_id": "2", "title": "Game 2"},
+    ]
+
+    response = client.get("/games?page=1&limit=2")
+    assert response.status_code == 200
+    assert response.json() == [
+        {"_id": "1", "title": "Game 1"},
+        {"_id": "2", "title": "Game 2"},
+    ]
+
+
+@patch("app.routes.get_game_by_id", new_callable=AsyncMock)
+@pytest.mark.asyncio
+async def test_get_game_by_id(mock_get_game):
+    mock_get_game.return_value = {"_id": "1", "title": "Game 1"}
+
+    response = client.get("/games/1")
+    assert response.status_code == 200
+    assert response.json() == {"_id": "1", "title": "Game 1"}
+


### PR DESCRIPTION
## Summary
- introduce `games_service` with helpers to fetch games
- expose `/games` and `/games/{game_id}` endpoints
- document the new endpoints in README
- test the new routes

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_68496f18d4e8832696c7250cd499f2fc